### PR TITLE
Properly anchor patterns to prevent false matches

### DIFF
--- a/src/systemd_files/noxaarchup.sh
+++ b/src/systemd_files/noxaarchup.sh
@@ -2,9 +2,9 @@
 
 # based on script from https://aur.archlinux.org/packages/batterylife
 call_aarchup(){
-    dbus=$(grep -z DBUS_SESSION_BUS_ADDRESS $1 | sed 's/DBUS_SESSION_BUS_ADDRESS=//')
-    user=$(grep -m 1 -z USER $1 | sed 's/USER=//')
-    dply=$(grep -z DISPLAY $1 | sed 's/DISPLAY=//')
+    dbus=$(grep -z '^DBUS_SESSION_BUS_ADDRESS=' $1 | sed 's/DBUS_SESSION_BUS_ADDRESS=//')
+    user=$(grep -m 1 -z '^USER=' $1 | sed 's/USER=//')
+    dply=$(grep -z '^DISPLAY=' $1 | sed 's/DISPLAY=//')
     sudo -u $user sh -c "DBUS_SESSION_BUS_ADDRESS=\"$dbus\" DISPLAY=\"$dply\" /usr/bin/aarchup"   
 }
 


### PR DESCRIPTION
This was causing an issue on environments where USERNAME was appearing before USER;
grep would match USERNAME but then sed would fail to remove anything leading to an invalid $user.