### PR TITLE
Fix systemd units

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -41,16 +41,16 @@ install:
 	install -Dm774 archlogo.svg $(DESTDIR)/usr/share/aarchup/archlogo.svg
 	install -Dm774 archlogo.png $(DESTDIR)/usr/share/aarchup/archlogo.png
 	install -Dm755 systemd_files/noxaarchup.sh $(DESTDIR)/usr/share/aarchup/noxaarchup.sh
-	install -Dm644 systemd_files/aarchup.timer $(DESTDIR)/etc/systemd/system/aarchup.timer
-	install -Dm644 systemd_files/aarchup.service $(DESTDIR)/etc/systemd/system/aarchup.service
+	install -Dm644 systemd_files/aarchup.timer $(DESTDIR)/usr/lib/systemd/user/aarchup.timer
+	install -Dm644 systemd_files/aarchup.service $(DESTDIR)/usr/lib/systemd/user/aarchup.service
 
 uninstall:
 	rm -f $(DESTDIR)/usr/bin/aarchup
 	rm -rf $(DESTDIR)/usr/share/doc/aarchup
 	rm -f $(DESTDIR)/usr/share/man/man1/aarchup.1.gz
 	rm -rf $(DESTDIR)/usr/share/aarchup
-	rm -f $(DESTDIR)/etc/systemd/system/aarchup.timer
-	rm -f $(DESTDIR)/etc/systemd/system/aarchup.service
+	rm -f $(DESTDIR)/usr/lib/systemd/user/aarchup.timer
+	rm -f $(DESTDIR)/usr/lib/systemd/user/aarchup.service
 
 distclean:
 	rm -rf aarchup autoscan.log autom4te.cache Makefile configure.scan configure config.*

--- a/src/aarchup.1
+++ b/src/aarchup.1
@@ -95,7 +95,13 @@ Now every hour your package database will get updated and after that aarchup wil
 
 \fIother Intervals\fR
 
-If you want to execute aarchup at other intervals than hourly you are free to do so simply by editing the file /etc/systemd/system/aarchup.timer
+If you want to execute aarchup at other intervals than hourly, you can override the settings of the systemd timer unit by either ...
+.PP
+* Using the \fisystemctl --user edit $UNITNAME\fr command to interactively create an override file for the unit in \fi~/.config/systemd/user/$UNITNAME.d/\fr where $UNITNAME stands for the name of the systemd unit. 
+
+* Or by creating an override file in the aforementioned directory, followed by executing \fisystemctl --user daemon-reload\fr
+.PP
+After you made the change, you need to restart the unit as well.
 
 Some hints on this:
  * you can adjust the timeout value, before the notification will disappear with the --timeout option of aarchup


### PR DESCRIPTION
These two commits fix the paths to the systemd units and where they are stored, as well as the description for changing the interval of the check.